### PR TITLE
Added 3 string comparison methods, added deploy button to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 ## Apex Collections - chaining support for filtering Apex collections.
 
+<a href="https://githubsfdeploy.herokuapp.com">
+  <img alt="Deploy to Salesforce" src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png">
+</a>
+
 Salesforce's Apex implementation of Java has no support for lambdas, which makes working with the equivalent of IEnumerable<T> collections tiresome. Repeated "for(...) { method body }" loops abound
 in Apex code.
 

--- a/src/classes/Filter.cls
+++ b/src/classes/Filter.cls
@@ -187,6 +187,48 @@ public class Filter {
         return this;
     }
 
+    public Filter containsString(String otherValue) {
+        for(String key : this.mapOfMaps.keySet()) {
+            this.index = key;
+            this.ref = this.mapOfMaps.get(key);
+            this.value = get() != null ? get() : value;
+
+            if(String.valueOf(this.value).contains(otherValue)) {
+                this.cleanCollections();
+            }
+
+        }
+        return this;
+    }
+
+    public Filter startsWithString(String otherValue) {
+        for(String key : this.mapOfMaps.keySet()) {
+            this.index = key;
+            this.ref = this.mapOfMaps.get(key);
+            this.value = get() != null ? get() : value;
+
+            if(String.valueOf(this.value).startsWith(otherValue)) {
+                this.cleanCollections();
+            }
+
+        }
+        return this;
+    }
+
+    public Filter endsWithString(String otherValue) {
+        for(String key : this.mapOfMaps.keySet()) {
+            this.index = key;
+            this.ref = this.mapOfMaps.get(key);
+            this.value = get() != null ? get() : value;
+
+            if(String.valueOf(this.value).endsWith(otherValue)) {
+                this.cleanCollections();
+            }
+
+        }
+        return this;
+    }
+
     public Filter andReplaceFieldWithValueFrom(SObjectField fieldToAddValue, Map<String, SObject> replacementMap, SObjectField matchingField) {
         for(String key : this.mapOfMaps.keySet()) {
             this.ref = this.mapOfMaps.get(key);

--- a/src/classes/Filter.cls-meta.xml
+++ b/src/classes/Filter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>41.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Filter_Tests.cls
+++ b/src/classes/Filter_Tests.cls
@@ -55,6 +55,65 @@ private class Filter_Tests {
     }
 
     @isTest
+    static void it_should_remove_items_from_list_containing_string() {
+        String valueToCheck = 'Ooo, wee, Rick.';
+        con.Description = valueToCheck;
+        List<Contact> contacts = new List<Contact>{ con };
+
+        // Let's include a mini-test to prove why this 'containing' method is helpful
+        // Long text area fields can't be filtered in SOQL - mini-test to show that it would fail
+        try {
+            // Contact.Description is a long text area and can't be filtered in SOQL
+            List<Contact> willFailAtRuntime = Database.query('SELECT Id FROM Contact WHERE Description LIKE \'%' + valueToCheck + '%\'');
+        } catch(QueryException ex) {
+            String expectedErrorMessage = 'field \'Description\' can not be filtered in query call';
+            System.assert(ex.getMessage().contains(expectedErrorMessage));
+        }
+
+        // Real test time
+        Test.startTest();
+
+        Filter that = Filter.the(contacts)
+            .whereField(Schema.Contact.Description)
+            .containsString('Summer');
+
+        System.assertEquals(false, contacts.isEmpty());
+
+        that.containsString(valueToCheck);
+        System.assertEquals(true, contacts.isEmpty());
+
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_remove_items_from_list_that_starts_with_string() {
+        List<Contact> contacts = new List<Contact>{ con };
+
+        Filter that = Filter.the(contacts)
+            .whereField(Schema.Contact.Description)
+            .startsWithString('Look at me!');
+
+        System.assertEquals(false, contacts.isEmpty());
+
+        that.startsWithString('Ooo, wee');
+        System.assertEquals(true, contacts.isEmpty());
+    }
+
+    @isTest
+    static void it_should_remove_items_from_list_that_ends_with_string() {
+        List<Contact> contacts = new List<Contact>{ con };
+
+        Filter that = Filter.the(contacts)
+            .whereField(Schema.Contact.Description)
+            .endsWithString('Beth');
+
+        System.assertEquals(false, contacts.isEmpty());
+
+        that.endsWithString('Rick');
+        System.assertEquals(true, contacts.isEmpty());
+    }
+
+    @isTest
     static void it_should_return_map_of_filtered_values() {
         Map<Id, SObject> filteredMap = Filter.the(new List<Lead>{ ld })
             .byField(Lead.FirstName)
@@ -149,5 +208,5 @@ private class Filter_Tests {
     static final String testString = 'test@test.com';
     static final Lead ld = new Lead(Id = leadId, FirstName = 'Bird', LastName = 'Person');
     static final Account acc =  new Account(Id = accountId, Name = 'Morty');
-    static final Contact con = new ContacT(Id = contactId, FirstName = 'Pencil', LastName = 'Vester');
+    static final Contact con = new Contact(Id = contactId, FirstName = 'Pencil', LastName = 'Vester', Description = 'Ooo, wee, Rick');
 }

--- a/src/classes/Filter_Tests.cls-meta.xml
+++ b/src/classes/Filter_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>41.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>*</members>
+        <name>ApexClass</name>
+    </types>
+    <version>41.0</version>
+</Package>


### PR DESCRIPTION
@jamessimone  As you might know, I have some... issues with SOQL/SOSL. One of those issues is that fact that you can't filter on certain field types, like long text area, etc. I've  added 3 methods that help with some  situations that I've run into
1. **containsString** - 'Does the call note (task.Description) mention <something keyword>'
2. **startsWithString** - 'We have a convention where the notes always start with <foo>'
3. **endWithString** - 'I felt bad about implementing startsWithString without his friend, endWithString'

I also updated the API to 41.0 (I think 42 is only in sandboxes right now) and added a deploy button to readme.md

Let me know what you think!